### PR TITLE
Fix SAN disambiguation

### DIFF
--- a/src/pyffish.cpp
+++ b/src/pyffish.cpp
@@ -63,13 +63,7 @@ const string move_to_san(Position& pos, Move m) {
 
           // A disambiguation occurs if we have more then one piece of type 'pt'
           // that can reach 'to' with a legal move.
-          if (pt == SHOGI_PAWN
-             || pt == LANCE
-             || (pt == SILVER && UCI::square(pos, from)[0] == UCI::square(pos, to)[0])
-             )
-            others = b = Bitboard(0);
-          else
-            others = b = (attacks_bb(~us, pt, to, pos.pieces()) & pos.pieces(us, pt)) ^ from;
+          others = b = (attacks_bb(~us, pt, to, pos.pieces()) & pos.pieces(us, pt)) ^ from;
 
           while (b)
           {

--- a/test.py
+++ b/test.py
@@ -110,6 +110,10 @@ class TestPyffish(unittest.TestCase):
         result = sf.get_san("sittuyin", SITTUYIN, "R@a1")
         self.assertEqual(result, "R@a1")
 
+        fen = "3rr3/1kn3n1/1ss1p1pp/1pPpP3/6PP/p3KN2/2SSFN2/3R3R[] b - - 0 14"
+        result = sf.get_san("sittuyin", fen, "c6c5")
+        self.assertEqual(result, "Scxc5")
+
         result = sf.get_san("shogi", SHOGI, "1g1f")
         self.assertEqual(result, "P1f")
 


### PR DESCRIPTION
Maybe I am missing something, but to me the extra condition for the disambiguation is not necessary and actually breaks it for silvers, e.g., in sittuyin, see the test example.