### PR TITLE
Append equals sign to moves refraining from promotion

### DIFF
--- a/src/pyffish.cpp
+++ b/src/pyffish.cpp
@@ -93,6 +93,8 @@ const string move_to_san(Position& pos, Move m) {
           san += string("=") + pos.piece_to_char()[make_piece(WHITE, promotion_type(m))];
       else if (type_of(m) == PIECE_PROMOTION)
           san += string("+");
+      else if (type_of(m) == NORMAL && Options["Protocol"] == "usi" && pos.pseudo_legal(make<PIECE_PROMOTION>(from, to)))
+          san += string("=");
       else if (is_gating(m))
           san += string("/") + pos.piece_to_char()[make_piece(WHITE, gating_type(m))];
   }

--- a/test.py
+++ b/test.py
@@ -117,6 +117,12 @@ class TestPyffish(unittest.TestCase):
         result = sf.get_san("shogi", SHOGI, "1g1f")
         self.assertEqual(result, "P1f")
 
+        fen = "lnsgkgsnl/1r5b1/pppppp1pp/6p2/9/2P6/PP1PPPPPP/1B5R1/LNSGKGSNL[] b 2 2"
+        result = sf.get_san("shogi", fen, "8h2b")
+        self.assertEqual(result, "Bx2b=")
+        result = sf.get_san("shogi", fen, "8h2b+")
+        self.assertEqual(result, "Bx2b+")
+
         fen = "rnsm1s1r/4n1k1/1ppppppp/p7/2PPP3/PP3PPP/4N2R/RNSKMS2 b - - 1 5"
         result = sf.get_san("makruk", fen, "f8f7")
         self.assertEqual(result, "Sf7")


### PR DESCRIPTION
No matter which shogi notation we decide for, appending an equals sign to moves refraining from an optional piece promotion seems to be common for all of them.