### PR TITLE
Fix SAN for moves of promoted pieces

### DIFF
--- a/src/pyffish.cpp
+++ b/src/pyffish.cpp
@@ -57,7 +57,7 @@ const string move_to_san(Position& pos, Move m) {
           if (pt != PAWN)
           {
               if (pos.is_promoted(from) && Options["Protocol"] == "usi")
-                  san += "+" + toupper(pos.piece_to_char()[pos.unpromoted_piece_on(from)]);
+                  san += "+" + string(1, toupper(pos.piece_to_char()[pos.unpromoted_piece_on(from)]));
               else
                   san += pos.piece_to_char()[make_piece(WHITE, pt)];
 

--- a/test.py
+++ b/test.py
@@ -138,6 +138,10 @@ class TestPyffish(unittest.TestCase):
         result = sf.get_san("shogi", fen, "B*3c")
         self.assertEqual(result, "B*3c")
 
+        fen = "lnsgkg1nl/1r4s+B1/pppppp1pp/6p2/9/2P6/PP1PPPPPP/7R1/LNSGKGSNL b B"
+        result = sf.get_san("shogi", fen, "2b3c")
+        self.assertEqual(result, "+B-3c")
+
         fen = "rnsm1s1r/4n1k1/1ppppppp/p7/2PPP3/PP3PPP/4N2R/RNSKMS2 b - - 1 5"
         result = sf.get_san("makruk", fen, "f8f7")
         self.assertEqual(result, "Sf7")


### PR DESCRIPTION
Properly concatenate strings in order to avoid undefined behavior.

Just using "string + char" does not work, the char needs to be converted first.