### PR TITLE
Fix SAN disambiguation for cannon and horse

### DIFF
--- a/src/pyffish.cpp
+++ b/src/pyffish.cpp
@@ -65,12 +65,14 @@ const string move_to_san(Position& pos, Move m) {
 
               // A disambiguation occurs if we have more then one piece of type 'pt'
               // that can reach 'to' with a legal move.
-              others = b = (attacks_bb(~us, pt, to, pos.pieces()) & pos.pieces(us, pt)) ^ from;
+              others = b = ((pos.capture(m) ? attacks_bb(~us, pt == HORSE ? KNIGHT : pt, to, pos.pieces())
+                                            :   moves_bb(~us, pt == HORSE ? KNIGHT : pt, to, pos.pieces())) & pos.pieces(us, pt)) ^ from;
 
               while (b)
               {
                   Square s = pop_lsb(&b);
-                  if (   !pos.legal(make_move(s, to))
+                  if (   !pos.pseudo_legal(make_move(s, to))
+                      || !pos.legal(make_move(s, to))
                       || (Options["Protocol"] == "usi" && pos.unpromoted_piece_on(s) != pos.unpromoted_piece_on(from)))
                       others ^= s;
               }

--- a/test.py
+++ b/test.py
@@ -192,6 +192,19 @@ class TestPyffish(unittest.TestCase):
         result = sf.get_san("xiangqi", XIANGQI, "c1e3")
         self.assertEqual(result, "Ece3")
 
+        result = sf.get_san("xiangqi", XIANGQI, "h3h10")
+        self.assertEqual(result, "Cxh10")
+
+        result = sf.get_san("xiangqi", XIANGQI, "h3h5")
+        self.assertEqual(result, "Ch5")
+
+        fen = "1rb1ka2r/4a4/2ncb1nc1/p1p1p1p1p/9/2P6/P3PNP1P/2N1C2C1/9/R1BAKAB1R w - - 1 7"
+        result = sf.get_san("xiangqi", fen, "c3e2")
+        self.assertEqual(result, "Hce2")
+
+        result = sf.get_san("xiangqi", fen, "c3d5")
+        self.assertEqual(result, "Hd5")
+
         fen = "rnsm1s1r/4n1k1/1ppppppp/p7/2PPP3/PP3PPP/4N2R/RNSKMS2 b - - 1 5"
         result = sf.get_san("makruk", fen, "f8f7")
         self.assertEqual(result, "Sf7")


### PR DESCRIPTION
Make SAN disambiguation consider that:
- Cannons have different quiet and capture moves.
- Horses have asymmetrical moves regarding blocking pieces.

Resolves gbtami/pychess-variants#58.