### PR TITLE
Fix insufficient material adjudication for shako

### DIFF
--- a/src/pyffish.cpp
+++ b/src/pyffish.cpp
@@ -135,26 +135,25 @@ bool hasInsufficientMaterial(Color c, const Position& pos) {
     if (pos.count(c, PAWN) && pos.count<ALL_PIECES>() >= 4)
         return false;
 
-    if (pos.count(c, KNIGHT) >= 2 || (pos.count(c, KNIGHT) && (pos.count(c, BISHOP) || pos.count(c, FERS))))
+    if (pos.count(c, KNIGHT) >= 2 || (pos.count(c, KNIGHT) && (pos.count(c, BISHOP) || pos.count(c, FERS) || pos.count(c, FERS_ALFIL))))
         return false;
 
     // Check for opposite colored color-bound pieces
-    if (pos.count(c, BISHOP) && (DarkSquares & pos.pieces(BISHOP)) && (~DarkSquares & pos.pieces(BISHOP)))
+    if (   (pos.count(c, BISHOP) || pos.count(c, FERS_ALFIL))
+        && (DarkSquares & pos.pieces(BISHOP, FERS_ALFIL)) && (~DarkSquares & pos.pieces(BISHOP, FERS_ALFIL)))
         return false;
 
     if (pos.count(c, FERS) && (DarkSquares & pos.pieces(FERS)) && (~DarkSquares & pos.pieces(FERS)))
         return false;
 
+    if (pos.count(c, CANNON) && (pos.count(c, ALL_PIECES) > 2 || pos.count(~c, ALL_PIECES) > 1))
+        return false;
+
     // Pieces sufficient for stalemate (Xiangqi)
     if (pos.stalemate_value() != VALUE_DRAW)
-    {
         for (PieceType pt : { HORSE, SOLDIER })
             if (pos.count(c, pt))
                 return false;
-
-        if (pos.count(c, CANNON) && (pos.count(c, ALL_PIECES) > 2 || pos.count(~c, ALL_PIECES) > 1))
-            return false;
-    }
 
     return true;
 }

--- a/test.py
+++ b/test.py
@@ -53,6 +53,14 @@ variant_positions = {
         "4k4/9/4b4/9/9/9/9/4B4/9/4K4 w - - 0 1": (True, True),  # KB vs KB
         "4k4/9/9/9/9/9/9/9/4A4/4KC3 w - - 0 1": (False, True),  # KCA vs K
     },
+    "shako": {
+        "k9/10/10/10/10/10/10/10/10/KC8 w - - 0 1": (True, True),  # KC vs K
+        "k9/10/10/10/10/10/10/10/10/KCC7 w - - 0 1": (False, True),  # KCC vs K
+        "k9/10/10/10/10/10/10/10/10/KEC7 w - - 0 1": (False, True),  # KEC vs K
+        "k9/10/10/10/10/10/10/10/10/KNE7 w - - 0 1": (False, True),  # KNE vs K
+        "kb8/10/10/10/10/10/10/10/10/KE8 w - - 0 1": (False, False),  # KE vs KB opp color
+        "kb8/10/10/10/10/10/10/10/10/K1E7 w - - 0 1": (True, True),  # KE vs KB same color
+    }
 }
 
 


### PR DESCRIPTION
Cannons and shako-elephants (fers-alfil) were not considered in detection of sufficient mating material.