### PR TITLE
Add reproducible fishnet binary workflow

### DIFF
--- a/.github/workflows/fishnet.yml
+++ b/.github/workflows/fishnet.yml
@@ -53,18 +53,24 @@ jobs:
           compression-level: 9
 
   linux:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.runner }}
     container: ubuntu:20.04
     strategy:
       fail-fast: false
       matrix:
         include:
-          - arch: x86-64
+          - runner: ubuntu-24.04
+            arch: x86-64
             asset: stockfish-x86_64
-          - arch: x86-64-modern
+          - runner: ubuntu-24.04
+            arch: x86-64-modern
             asset: stockfish-x86_64-modern
-          - arch: x86-64-bmi2
+          - runner: ubuntu-24.04
+            arch: x86-64-bmi2
             asset: stockfish-x86_64-bmi2
+          - runner: ubuntu-24.04-arm
+            arch: armv8
+            asset: stockfish-aarch64
 
     steps:
       - name: Install build tools

--- a/.github/workflows/fishnet.yml
+++ b/.github/workflows/fishnet.yml
@@ -1,7 +1,10 @@
 name: Fishnet binaries
-run-name: Fishnet binaries for ${{ inputs.source_ref }}
+run-name: Fishnet binaries for ${{ inputs.source_ref || github.sha }}
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/fishnet.yml
   workflow_dispatch:
     inputs:
       source_ref:
@@ -35,7 +38,7 @@ jobs:
           disk-root: "C:"
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.source_ref }}
+          ref: ${{ inputs.source_ref || github.sha }}
       - name: Build
         working-directory: src
         run: make clean && make -j build COMP=mingw ARCH=${{ matrix.arch }} EXE=${{ matrix.asset }} largeboards=yes all=yes && strip ${{ matrix.asset }}
@@ -51,6 +54,7 @@ jobs:
 
   linux:
     runs-on: ubuntu-24.04
+    container: ubuntu:20.04
     strategy:
       fail-fast: false
       matrix:
@@ -63,9 +67,11 @@ jobs:
             asset: stockfish-x86_64-bmi2
 
     steps:
+      - name: Install build tools
+        run: apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --yes build-essential git
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.source_ref }}
+          ref: ${{ inputs.source_ref || github.sha }}
       - name: Build
         working-directory: src
         run: make clean && make -j build COMP=gcc ARCH=${{ matrix.arch }} EXE=${{ matrix.asset }} largeboards=yes all=yes && strip ${{ matrix.asset }}
@@ -95,7 +101,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.source_ref }}
+          ref: ${{ inputs.source_ref || github.sha }}
       - name: Build
         working-directory: src
         run: make clean && make -j build COMP=clang ARCH=${{ matrix.arch }} EXE=${{ matrix.asset }} largeboards=yes all=yes && strip ${{ matrix.asset }}

--- a/.github/workflows/fishnet.yml
+++ b/.github/workflows/fishnet.yml
@@ -1,0 +1,110 @@
+name: Fishnet binaries
+run-name: Fishnet binaries for ${{ inputs.source_ref }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_ref:
+        description: Git ref to build
+        required: true
+        default: master
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  windows:
+    runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86-64
+            asset: stockfish-windows-amd64.exe
+          - arch: x86-64-modern
+            asset: stockfish-windows-amd64-modern.exe
+          - arch: x86-64-bmi2
+            asset: stockfish-windows-amd64-bmi2.exe
+
+    steps:
+      - uses: al-cheb/configure-pagefile-action@v1.5
+        with:
+          minimum-size: 16GB
+          maximum-size: 16GB
+          disk-root: "C:"
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.source_ref }}
+      - name: Build
+        working-directory: src
+        run: make clean && make -j build COMP=mingw ARCH=${{ matrix.arch }} EXE=${{ matrix.asset }} largeboards=yes all=yes && strip ${{ matrix.asset }}
+      - name: Bench
+        working-directory: src
+        run: .\${{ matrix.asset }} bench
+      - uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.asset }}
+          path: src/${{ matrix.asset }}
+          if-no-files-found: error
+          compression-level: 9
+
+  linux:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86-64
+            asset: stockfish-x86_64
+          - arch: x86-64-modern
+            asset: stockfish-x86_64-modern
+          - arch: x86-64-bmi2
+            asset: stockfish-x86_64-bmi2
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.source_ref }}
+      - name: Build
+        working-directory: src
+        run: make clean && make -j build COMP=gcc ARCH=${{ matrix.arch }} EXE=${{ matrix.asset }} largeboards=yes all=yes && strip ${{ matrix.asset }}
+      - name: Bench
+        working-directory: src
+        run: ./${{ matrix.asset }} bench
+      - uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.asset }}
+          path: src/${{ matrix.asset }}
+          if-no-files-found: error
+          compression-level: 9
+
+  macos:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-15-intel
+            arch: x86-64
+            asset: stockfish-osx-x86_64
+          - runner: macos-14
+            arch: apple-silicon
+            asset: stockfish-osx-arm64
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.source_ref }}
+      - name: Build
+        working-directory: src
+        run: make clean && make -j build COMP=clang ARCH=${{ matrix.arch }} EXE=${{ matrix.asset }} largeboards=yes all=yes && strip ${{ matrix.asset }}
+      - name: Bench
+        working-directory: src
+        run: ./${{ matrix.asset }} bench
+      - uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.asset }}
+          path: src/${{ matrix.asset }}
+          if-no-files-found: error
+          compression-level: 9


### PR DESCRIPTION
## Summary

- add an on-demand workflow dedicated to fairyfishnet release binaries
- build every Windows, Linux, Intel macOS, and Apple Silicon asset with both `largeboards=yes` and `all=yes`
- run `bench` on every binary on its native runner before upload
- name uploaded binaries exactly as fairyfishnet selects them
- accept a source ref so an existing fishnet tag can be rebuilt reproducibly

The current general release workflow already builds the two macOS `all` binaries correctly, but does not build `all=yes` for the optimized Windows/Linux matrices. Keeping fishnet packaging separate makes the required feature set explicit and avoids publishing mixed-provenance assets.

After merge, dispatching this workflow with `source_ref=fishnet-050326` will regenerate provenance-matched `stockfish-osx-x86_64` and `stockfish-osx-arm64` assets for gbtami/fairyfishnet#65.

## Validation

- `actionlint .github/workflows/fishnet.yml`
