### PR TITLE
Release bindings with corrected Dobutsu rules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ pyffish_module = Extension(
     depends=headers,
     extra_compile_args=args)
 
-setup(name="pyffish", version="0.0.89",
+setup(name="pyffish", version="0.0.90",
       description="Fairy-Stockfish Python wrapper",
       long_description=long_description,
       long_description_content_type="text/markdown",

--- a/src/pyffish.cpp
+++ b/src/pyffish.cpp
@@ -54,7 +54,7 @@ void buildPosition(Position& pos, StateListPtr& states, const char *variant, con
 }
 
 extern "C" PyObject* pyffish_version(PyObject* self) {
-    return Py_BuildValue("(iii)", 0, 0, 89);
+    return Py_BuildValue("(iii)", 0, 0, 90);
 }
 
 extern "C" PyObject* pyffish_info(PyObject* self) {

--- a/tests/js/package.json
+++ b/tests/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffish",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "description": "A high performance WebAssembly chess variant library based on Fairy-Stockfish",
   "main": "ffish.js",
   "types": "ffish.d.ts",

--- a/tests/js/test.js
+++ b/tests/js/test.js
@@ -468,6 +468,25 @@ describe('board.result()', function () {
   })
 })
 
+describe('Dobutsu game end conditions', function () {
+  it('requires a safe lion for a try win', () => {
+    const fen = '1L1/1g1/1G1/1l1[] w - - 0 1';
+    const cases = [
+      ['b2a2', '0-1'],
+      ['b4a4', '1-0'],
+      ['b2b3', '1/2-1/2'],
+      ['b4b3', '*'],
+    ];
+
+    for (const [move, result] of cases) {
+      const board = new ffish.Board('dobutsu', fen);
+      chai.expect(board.push(move), move).to.equal(true);
+      chai.expect(board.result(), move).to.equal(result);
+      board.delete();
+    }
+  });
+});
+
 describe('board.checkedPieces()', function () {
   it("it returns the squares of all checked royal pieces in a concatenated string", () => {
     let board = new ffish.Board();


### PR DESCRIPTION
## Summary

- bump pyffish from 0.0.89 to 0.0.90
- bump ffish and ffish-es6 from 0.7.9 to 0.7.10
- cover the corrected Dobutsu safe-lion try outcomes in the JavaScript binding suite

The previous binding releases were published before upstream commit f544ae77 fixed Dobutsu game-end conditions.

## Validation

- built ffish.js with Emscripten 1.39.16 and ran the Node 12 suite: 59 passed
- built the pyffish extension with Python 3.14 and ran test.py: 22 passed
- git diff --check